### PR TITLE
AMD "Ember" dependency to lowercase "ember"

### DIFF
--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
           output = [];
 
       if (options.amd) {
-        output = output.concat('define(["Ember"],function(Ember){');
+        output = output.concat('define(["ember"], function(Ember){');
       }
 
       f.src.forEach(function(file) {
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
       output = output.concat(templates);
 
       if (options.amd) {
-        output = output.concat('});');
+        output = output.concat('});\n');
       }
 
       if (output.length > 0) {

--- a/test/expected/amd.js
+++ b/test/expected/amd.js
@@ -1,4 +1,4 @@
-define(["Ember"],function(Ember){
+define(["ember"], function(Ember){
 
 Ember.TEMPLATES["test/fixtures/text"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
 this.compilerInfo = [4,'>= 1.0.0'];


### PR DESCRIPTION
tools integrating with bower and requirejs will
have ember listed as "ember" not "Ember", its
also general convention to have lowercase module
identifiers: jQuery also registers as 'jquery'.
