### PR TITLE
Add a preprocess callback option.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,6 +98,16 @@ module.exports = function(grunt) {
                                                     'test/fixtures/grandparent/parent/child.hbs']
         }
       },
+      minify: {
+        options: {
+          preprocess: function (source) {
+            return source.replace(/\s+/g, ' ');
+          }
+        },
+        files: {
+          'tmp/preprocess.js': ['test/fixtures/custom_file_extensions/preprocess.minhbs']
+        }
+      },
       skipPrecompile: {
         options: {
           precompile: false

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -58,12 +58,19 @@ module.exports = function(grunt) {
 
           if (options.precompile) {
 
+            var template = grunt.file.read(file);
+
+            // Run the `preprocess` function if specified in the options.
+            if (typeof options.preprocess === 'function') {
+              template = options.preprocess(template);
+            }
+
             // Create a context into which we will load both the ember template compiler
             // as well as the template to be compiled. The ember template compiler expects
             // `exports` to be defined, and uses it to export `precompile()`.
             var context = vm.createContext({
               exports: {},
-              template: grunt.file.read(file)
+              template: template
             });
 
             // Load handlebars

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -71,6 +71,16 @@ exports.handlebars = {
 
     test.done();
   },
+  minify: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/preprocess.js');
+    var expected = grunt.file.read('test/expected/preprocess.js');
+    test.equal(actual, expected, 'should be able to run a preprocess function');
+
+    test.done();
+  },
   skip_precompile: function(test) {
     'use strict';
     test.expect(1);

--- a/test/expected/preprocess.js
+++ b/test/expected/preprocess.js
@@ -1,0 +1,15 @@
+Ember.TEMPLATES["test/fixtures/custom_file_extensions/preprocess.minhbs"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  var buffer = '', stack1, hashTypes, hashContexts, options, helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+
+
+  data.buffer.push("<div> <div>Spaces</div> <div>Tabs</div> <div class=\"spaces in attrs\"></div> ");
+  hashTypes = {};
+  hashContexts = {};
+  options = {hash:{},contexts:[depth0,depth0,depth0],types:["ID","ID","ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data};
+  data.buffer.push(escapeExpression(((stack1 = helpers.spaces || depth0.spaces),stack1 ? stack1.call(depth0, "in", "handlebars", "tags", options) : helperMissing.call(depth0, "spaces", "in", "handlebars", "tags", options))));
+  data.buffer.push(" </div>");
+  return buffer;
+  
+});

--- a/test/fixtures/custom_file_extensions/preprocess.minhbs
+++ b/test/fixtures/custom_file_extensions/preprocess.minhbs
@@ -1,0 +1,8 @@
+<div>
+    <div>Spaces</div>
+	<div>Tabs</div>
+
+
+	<div   class="spaces  in   attrs"></div>
+	{{    spaces in handlebars tags   }}
+</div>


### PR DESCRIPTION
Addresses #38.

Allows you to set a `preprocess:function` callback to manipulate the input before it gets passed to the handlebars compiler.

Here is an example that compresses consecutive whitespace characters into a single character.

``` javascript
preprocess : function (source) {
    return source.replace(/\s+/g, ' ');
}
```

Before:

``` html
<div>
    <p class="mini   doge">Wow</p>

        <span>So save</span>
    <p>Much compress</p>
</div>
```

After:

``` html
<div> <p class="mini doge">Wow</p> <span>So save</span> <p>Much compress</p> </div>
```
