### PR TITLE
Remove leading slash from module name.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,6 +69,16 @@ module.exports = function(grunt) {
                                         'test/fixtures/grandparent/parent/child.hbs']
         }
       },
+      removeLeadingSlash: {
+        options: {
+          templateBasePath: /test\/fixtures/
+        },
+        files: {
+          'tmp/remove_leading_slash.js': ['test/fixtures/text.hbs',
+                                          'test/fixtures/simple.hbs',
+                                          'test/fixtures/grandparent/parent/child.hbs']
+        }
+      },
       customTemplateName: {
         options: {
           templateName: function(name) {

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -29,6 +29,11 @@ module.exports = function(grunt) {
             file = file.replace(match, '');
           }
         });
+
+        if (file.charAt(0) === '/'){
+          file = file.slice(1);
+        }
+
         return options.templateName(file);
       },
       templateRegistration: function(name, contents) {

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -51,6 +51,16 @@ exports.handlebars = {
 
     test.done();
   },
+  remove_leading_slash: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/remove_leading_slash.js');
+    var expected = grunt.file.read('test/expected/truncate_base_path.js');
+    test.equal(actual, expected, 'should remove leading slash from template names');
+
+    test.done();
+  },
   custom_template_name: function(test) {
     'use strict';
     test.expect(1);


### PR DESCRIPTION
I do not think that a module name starting with `/` is ever desired
(this is usually a result of misconfiguration).

This change can easily be overridden by providing a custom
`templateForFileName` option.

Closes #55.
