### PR TITLE
Require Node.js >= 0.8.19.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.8.19"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This project is using peerDependencies to ensure that the ember-template-compiler (and it uses them for Handlebars) dependency is setup properly (and can be overridden by our consumers). In practice this works wonderfully, but a few users with older Node.js and/or NPM versions simple get a broken build. This is because Node.js < 0.8.19 did not have the ability to handle peerDependencies specified in the package.json.

This changes to ensure that at least 0.8.19 (well over a year old) is used, and provides the user with a reasonable error message (indicating that their Node.js version is too old).

If this is unacceptable, we could attempt to detect this upon first use, and fail loudly if our deps are not found...
