### PR TITLE
Proposal: AMD dependency customization

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,26 @@ module.exports = function(grunt) {
                          'test/fixtures/grandparent/parent/child.hbs']
         }
       },
+      amdStringTrue: {
+        options: {
+          amd: 'true'
+        },
+        files: {
+          'tmp/amd_string_true.js': ['test/fixtures/text.hbs',
+                                     'test/fixtures/simple.hbs',
+                                     'test/fixtures/grandparent/parent/child.hbs']
+        }
+      },
+      amdCustom: {
+        options: {
+          amd: 'custom'
+        },
+        files: {
+          'tmp/amd_custom.js': ['test/fixtures/text.hbs',
+                                'test/fixtures/simple.hbs',
+                                'test/fixtures/grandparent/parent/child.hbs']
+        }
+      },
       filePatternMatching: {
         files: {
           'tmp/file_pattern_matching.js': 'test/fixtures/{simple,text}.hbs'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This controls how this task operates and should contain key:value pairs. See spe
 
 ##### amd
 
-Type: `boolean`
+Type: `boolean | string`
 Default: `false`
 
 Include this option to ensure that the compiled output will be defined as a
@@ -50,9 +50,13 @@ single AMD module with a single dependency (`ember`). If you'd like to output
 individual templates as modules, skip this option and use the
 `templateRegistration` option described below.
 
+If you'd like to customize the module name for Ember, pass this option a string.
+(For backwards compatibility, the string `"true"` acts like the boolean `true`,
+and will result in `ember` being used as the module name. )
+
 ``` javascript
 options: {
-  amd: true
+  amd: "vendor/ember"
 }
 ```
 

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -75,10 +75,13 @@ module.exports = function(grunt) {
       var processedTemplates = [],
           output = [],
           name,
+          customAmd,
           contents;
 
       if (options.amd) {
-        output = output.concat('define(["ember"], function(Ember){');
+        customAmd = typeof options.amd === 'string' && options.amd !== 'true';
+        customAmd = customAmd ? options.amd : 'ember';
+        output = output.concat('define(["' + customAmd + '"], function(Ember){');
       }
 
       f.src.forEach(function(file) {

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -21,6 +21,26 @@ exports.handlebars = {
 
     test.done();
   },
+  amd_string_true: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/amd_string_true.js');
+    var expected = grunt.file.read('test/expected/amd.js');
+    test.equal(actual, expected, 'should compile handlebars templates with backwards compatible AMD wrappers');
+
+    test.done();
+  },
+  amd_custom: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/amd_custom.js');
+    var expected = grunt.file.read('test/expected/amd_custom.js');
+    test.equal(actual, expected, 'should compile handlebars templates with custom AMD wrappers');
+
+    test.done();
+  },
   file_pattern_matching: function(test) {
     'use strict';
     test.expect(1);

--- a/test/expected/amd_custom.js
+++ b/test/expected/amd_custom.js
@@ -1,0 +1,37 @@
+define(["custom"], function(Ember){
+
+Ember.TEMPLATES["test/fixtures/text"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  
+
+
+  data.buffer.push("Basic template that does nothing.");
+  
+});
+
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  var buffer = '', stack1;
+
+
+  data.buffer.push("<p>Hello, my name is ");
+  stack1 = helpers._triageMustache.call(depth0, "name", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
+  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+  data.buffer.push(".</p>");
+  return buffer;
+  
+});
+
+Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  
+
+
+  data.buffer.push("Should be nested.");
+  
+});
+
+});


### PR DESCRIPTION
This Pull Request is intended to open a discussion, not necessarily be merged as-is. If you're in favor, I'll clean up, add documentation, and update the tests.

What would you think of allowing `options.amd` to be a boolean _or_ a string? If it's a string, we'd use that string as the dependency name, and if it's a boolean we'd use `'ember'` as before. This maintains backwards compatibility, while allowing people to customize what Ember.js's AMD ID is in their project.
