### PR TITLE
Add 'concatenate' option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,6 +167,16 @@ module.exports = function(grunt) {
         files: {
           'tmp/custom_handlebars_path.js': ['test/fixtures/text.hbs']
         }
+      },
+      concatenateDisabled: {
+        options: {
+          concatenate: false,
+        },
+        files: {
+          'tmp/dest': ['test/fixtures/text.hbs',
+                       'test/fixtures/simple.hbs'],
+          'tmp/dest/slash/': ['test/fixtures/simple.hbs']
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ options: {
 }
 ```
 
+##### concatenate
+
+Type: `boolean`
+Default: `true`
+
+Disable this option to compile the templates to multiple individual files,
+rather than concatenating them into a single file. When concatenation is
+disabled, the destination property specifies the folder where compiled templates
+will be placed. The directory and file structure will mirror the source.
+
+This option is useful for situations where you'd like to let a build optimizer
+concatenate files in particular ways.
+
+``` javascript
+options: {
+  concatenate: false
+},
+files: {
+  "path/to/destination/folder": ["path/to/sources/*.handlebars", "path/to/more/*.handlebars"]
+}
+```
+
 ##### precompile
 
 Type: `boolean`

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -140,5 +140,25 @@ exports.handlebars = {
     test.ok(/WOOT/.test(actual), 'should use the provided handlebarsPath');
 
     test.done();
+  },
+  concatenate_disabled: function(test){
+    'use strict';
+    test.expect(3);
+
+    var desc = 'should write individual files if concatenation is disabled';
+
+    var actual = grunt.file.read('tmp/dest/test/fixtures/text.js');
+    var expected = grunt.file.read('test/expected/text.js');
+    test.equal(actual, expected, desc);
+
+    actual = grunt.file.read('tmp/dest/test/fixtures/simple.js');
+    expected = grunt.file.read('test/expected/simple.js');
+    test.equal(actual, expected, desc);
+
+    actual = grunt.file.read('tmp/dest/slash/test/fixtures/simple.js');
+    expected = grunt.file.read('test/expected/simple.js');
+    test.equal(actual, expected, desc);
+
+    test.done();
   }
 };

--- a/test/expected/simple.js
+++ b/test/expected/simple.js
@@ -1,0 +1,13 @@
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  var buffer = '', stack1;
+
+
+  data.buffer.push("<p>Hello, my name is ");
+  stack1 = helpers._triageMustache.call(depth0, "name", {hash:{},hashTypes:{},hashContexts:{},contexts:[depth0],types:["ID"],data:data});
+  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
+  data.buffer.push(".</p>");
+  return buffer;
+  
+});

--- a/test/expected/text.js
+++ b/test/expected/text.js
@@ -1,0 +1,9 @@
+Ember.TEMPLATES["test/fixtures/text"] = Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
+this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+  
+
+
+  data.buffer.push("Basic template that does nothing.");
+  
+});


### PR DESCRIPTION
In some situations, we'd like to output the compiled templates as
individual files. For example, suppose you have a dependency graph where
there are many views, and the templates corresponding to each view are
discoverable via the graph.

In this case, it makes sense to keep all templates as individual files,
and allow the build optimizer to concatenate the templates along with
the individual view's code, so that views can be loaded lazily.
