### PR TITLE
Allow specifying an alternate template namespace.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,6 +168,14 @@ module.exports = function(grunt) {
           'tmp/custom_handlebars_path.js': ['test/fixtures/text.hbs']
         }
       },
+      customTemplateNamespace: {
+        options: {
+          templateNamespace: 'HTMLBars'
+        },
+        files: {
+          'tmp/custom_template_namespace.js': ['test/fixtures/text.hbs']
+        }
+      },
       concatenateDisabled: {
         options: {
           concatenate: false,

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -18,6 +18,7 @@ function manualCompile(handlebarsPath, templateCompilerPath, template){
   // as well as the template to be compiled. The ember template compiler expects
   // `exports` to be defined, and uses it to export `precompile()`.
   var context = vm.createContext({
+    module: {},
     exports: {},
     template: template
   });
@@ -29,7 +30,7 @@ function manualCompile(handlebarsPath, templateCompilerPath, template){
   vm.runInContext(templateCompilerJs, context, 'ember-template-compiler.js');
 
   // Compile the template
-  vm.runInContext('compiledJS = exports.precompile(template);', context);
+  vm.runInContext('compiledJS = (module.exports || exports).precompile(template);', context);
 
   return context.compiledJS;
 };
@@ -78,7 +79,8 @@ module.exports = function(grunt) {
         return 'Ember.TEMPLATES[' + JSON.stringify(name) + '] = ' + contents + ';'
       },
       handlebarsPath: null,
-      templateCompilerPath: null
+      templateCompilerPath: null,
+      templateNamespace: 'Handlebars'
     });
 
     grunt.verbose.writeflags(options, 'Options');
@@ -119,10 +121,10 @@ module.exports = function(grunt) {
             }
 
             // Wrap compiled template
-            contents = 'Ember.Handlebars.template(' + compiledTemplate + ')';
+            contents = 'Ember.' + options.templateNamespace + '.template(' + compiledTemplate + ')';
           } else {
             // Wrap raw (uncompiled) template
-            contents = 'Ember.Handlebars.compile(' + JSON.stringify(grunt.file.read(file)) + ')';
+            contents = 'Ember.' + options.templateNamespace + '.compile(' + JSON.stringify(grunt.file.read(file)) + ')';
           }
 
           processedTemplates.push({

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -141,6 +141,16 @@ exports.handlebars = {
 
     test.done();
   },
+  custom_template_namespace: function(test){
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/custom_template_namespace.js');
+
+    test.ok(/Ember\.HTMLBars\.template/.test(actual), 'should use the provided namespace');
+
+    test.done();
+  },
   concatenate_disabled: function(test){
     'use strict';
     test.expect(3);


### PR DESCRIPTION
Allows precompiling HTMLBars templates.

``` javascript
emberTemplates: {
  options: {
    templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
    handlebarsPath: 'bower_components/handlebars/handlebars.js',
    templateNamespace: 'HTMLBars'
  },
  files: {
    'tmp/templates.js': 'app/templates/**/*.hbs'
  }
}
```
