### PR TITLE
Remove old dependencies, update Readme, bumped version to v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 0.12
 before_script:
-  - npm install -g grunt-cli
+  - npm install -g grunt-cli bower
+  - bower install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
         undef: true,
         boss: true,
         eqnull: true,
-        node: true,
+        node: true
       }
     },
 
@@ -160,7 +160,6 @@ module.exports = function(grunt) {
       },
       customTemplateCompiler: {
         options: {
-          handlebarsPath: 'test/fixtures/dummy-handlebars.js',
           templateCompilerPath: 'test/fixtures/dummy-template-compiler.js'
         },
         files: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -176,7 +176,7 @@ module.exports = function(grunt) {
       },
       concatenateDisabled: {
         options: {
-          concatenate: false,
+          concatenate: false
         },
         files: {
           'tmp/dest': ['test/fixtures/text.hbs',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,6 @@ module.exports = function(grunt) {
         boss: true,
         eqnull: true,
         node: true,
-        es5: true
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `^0.4.5`.
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -17,19 +17,43 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 ```js
 grunt.loadNpmTasks('grunt-ember-templates');
 ```
+### Grunt Ember Templates v1.0 compatible with Ember v1.10+
 
-#### Using Ember v1.10+?
+If you use earlier version of Ember, please use the `grunt-ember-templates` `v0.6`.
 
-If you're using a version of Ember greater than 1.9.1, you will need to configure grunt-ember-templates differently. The Ember template compiler now ships exclusively with the Ember dependency itself, so the path to that file will need to be configured specifically. Retrieve both the Ember AND the Handlebars dependencies, and include the path in the options object used by the `emberTemplates` task.
+### Getting Started
 
-Required for Ember v1.10+:
+* Install Ember.js with bower: `$ bower install ember --save`
+* Install this package with: `$ npm install grunt-ember-templates@~1.0.0 --save-dev`
+* Create an `app/templates` folder for your `hbs` files. Create a few `hbs` files there.
+* Create a basic `Gruntfile.js`:
+
 ```javascript
-options: {
-  templateCompilerPath: 'vendor/ember/ember-template-compiler.js',
-  handlebarsPath: 'vendor/handlebars/handlebars.js'
+module.exports = function(grunt) {
+
+  grunt.loadNpmTasks('grunt-ember-templates');
+
+  grunt.initConfig({
+    emberTemplates: {
+      default: {
+        options: {
+          templateBasePath: 'app/templates'
+        },
+        files: {
+          "tmp/templates.js": ["app/templates/**/*.hbs"]
+        }
+      }
+    }
+  })
+
+  grunt.registerTask('default', ['emberTemplates']);
 }
 ```
-See the documentation below for more information on these options.
+
+* (Optional: Install grunt-cli with `$ npm install -g grunt-cli` and install `grunt` locally with `$ npm install grunt --save-dev`.)
+* Run `grunt` in your console.
+
+You can find the compiled `templates.js` in `tmp` folder.
 
 ### Overview
 
@@ -230,29 +254,22 @@ options: {
 }
 ```
 
-##### templateCompilerPath and handlebarsPath
+##### templateCompilerPath
 
 Type: `string`
-Default: Not specified
+Default: `bower_components/ember/ember-template-compiler.js`
 
-By default, the template compiler and Handlebars included with the
-`ember-template-compiler` dependency will be used to compile templates.
-
-This option allows these defaults to be overridden in order to specify
-different versions of the template compiler and Handlebars.
+This option allows this default to be overridden to different version of the `ember-template-compiler.js`.
 
 For example, if there are upstream changes in Ember's compiler that haven't yet
 been published with `ember-template-compiler`, you could specify paths to local
-versions of the template compiler and Handlebars as follows:
+versions of the template compiler:
 
 ```javascript
 options: {
-  templateCompilerPath: 'vendor/ember/ember-template-compiler.js',
-  handlebarsPath: 'vendor/handlebars/handlebars.js'
+  templateCompilerPath: 'vendor/ember/ember-template-compiler.js'
 }
 ```
-
-IMPORTANT: These options must both be specified, or neither will take effect.
 
 #### Config Example
 
@@ -312,6 +329,9 @@ I created this project as an alternative to grunt-ember-handlebars for the follo
 
 ## Release History
 
+* 2016/03/28 - v1.0.0 - Removed `ember-template-compiler` and `handlebar` npm dependencies.
+                        Removed `handlebarsPath` option.
+                        Default: using the bundled `ember-template-compiler.js` from Ember.js bower package.
 * 2015/02/09 - v0.5.0 - HTMLBars is now the default template namespace.
 * 2014/11/17 - v0.5.0-alpha - Handlebars 2.0 compatibility via alpha ember-template-compiler. Thanks @smounir!
 * 2014/10/29 - v0.4.23 - Fixed peer dependencies issue for `ember-template-compiler` 1.8.x

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 ```js
 grunt.loadNpmTasks('grunt-ember-templates');
 ```
-### Grunt Ember Templates v1.0 compatible with Ember v1.10+
+### grunt-ember-templates v1.0 compatible with Ember v1.10+
 
 If you use earlier version of Ember, please use the `grunt-ember-templates` `v0.6`.
 
-### Getting Started
+### The most basic example
 
 * Install Ember.js with bower: `$ bower install ember --save`
 * Install this package with: `$ npm install grunt-ember-templates@~1.0.0 --save-dev`

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,6 @@
+{
+  "name": "grunt-ember-templates",
+  "dependencies": {
+    "ember": "~1.12.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ember-templates",
   "description": "Compile Handlebars templates for Ember in Grunt. Features destination:source file arguments and customizable template names.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "homepage": "https://github.com/dgeb/grunt-ember-templates",
   "author": {
     "name": "Dan Gebhardt",
@@ -28,17 +28,14 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-internal": "~0.4.2",
-    "grunt": "~0.4.0",
-    "ember-template-compiler": "~1.9.0-alpha"
+    "grunt": "~0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0",
-    "ember-template-compiler": "~1.9.0-alpha",
-    "handlebars": "~2.0.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ember-templates",
   "description": "Compile Handlebars templates for Ember in Grunt. Features destination:source file arguments and customizable template names.",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "homepage": "https://github.com/dgeb/grunt-ember-templates",
   "author": {
     "name": "Dan Gebhardt",

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -10,12 +10,15 @@ function manualCompile(templateCompilerPath, template, grunt){
   'use strict';
 
   var fs = require('fs'),
-      vm = require('vm');
+      vm = require('vm'),
+      templateCompilerJs;
 
   try {
-    var templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
+    templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
   } catch (e) {
-    if (e.code !== 'ENOENT') throw e;
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
     grunt.fail.warn('Please setup templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
   }
 
@@ -81,6 +84,7 @@ module.exports = function(grunt) {
       templateRegistration: function(name, contents) {
         return 'Ember.TEMPLATES[' + JSON.stringify(name) + '] = ' + contents + ';';
       },
+      // Default location of the compiler when ember installed with bower.
       templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
       templateNamespace: 'HTMLBars'
     });

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -6,18 +6,17 @@
  * https://github.com/dgeb/grunt-ember-templates/blob/master/LICENSE
  */
 
-function manualCompile(handlebarsPath, templateCompilerPath, template, grunt){
+function manualCompile(templateCompilerPath, template, grunt){
   'use strict';
 
   var fs = require('fs'),
       vm = require('vm');
 
   try {
-    var handlebarsJs       = fs.readFileSync(handlebarsPath, 'utf8'),
-        templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
+    var templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
   } catch (e) {
     if (e.code !== 'ENOENT') throw e;
-    grunt.fail.warn('Please setup handlebarsPath and templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
+    grunt.fail.warn('Please setup templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
   }
 
   // Create a context into which we will load both the ember template compiler
@@ -30,9 +29,6 @@ function manualCompile(handlebarsPath, templateCompilerPath, template, grunt){
     global: {},
     template: template
   });
-
-  // Load handlebars
-  vm.runInContext(handlebarsJs, context, 'handlebars.js');
 
   // Load the ember template compiler
   vm.runInContext(templateCompilerJs, context, 'ember-template-compiler.js');
@@ -85,7 +81,6 @@ module.exports = function(grunt) {
       templateRegistration: function(name, contents) {
         return 'Ember.TEMPLATES[' + JSON.stringify(name) + '] = ' + contents + ';';
       },
-      handlebarsPath: 'bower_components/ember/ember-template-compiler.js',
       templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
       templateNamespace: 'HTMLBars'
     });
@@ -121,11 +116,7 @@ module.exports = function(grunt) {
               template = options.preprocess(template);
             }
 
-            if (options.handlebarsPath && options.templateCompilerPath) {
-              compiledTemplate = manualCompile(options.handlebarsPath, options.templateCompilerPath, template, grunt);
-            } else {
-              grunt.fail.warn('Please setup handlebarsPath and templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
-            }
+            compiledTemplate = manualCompile(options.templateCompilerPath, template, grunt);
 
             // Wrap compiled template
             contents = 'Ember.' + options.templateNamespace + '.template(' + compiledTemplate + ')';
@@ -167,10 +158,4 @@ module.exports = function(grunt) {
   };
 
   grunt.registerMultiTask('emberTemplates', 'Compile Handlebars templates for Ember.', emberTemplatesTask);
-
-  // TODO: remove deprecated `ember_templates` task from v0.5
-  grunt.registerMultiTask('ember_templates', 'Compile Handlebars templates for Ember. [DEPRECATED: please use `emberTemplates` instead]', function() {
-    grunt.log.warn('`ember_templates` is deprecated and will be removed in v0.5. Please use `emberTemplates` instead.');
-    emberTemplatesTask.apply(this, arguments);
-  });
 };

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -19,7 +19,7 @@ function manualCompile(templateCompilerPath, template, grunt){
     if (e.code !== 'ENOENT') {
       throw e;
     }
-    grunt.fail.warn('Please setup templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
+    grunt.fail.warn('ember-template-compiler.js is not found. You can install with `bower install ember --save`. If you would like to use a custom location you can setup `templateCompilerPath` option in Gruntfile.js. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
   }
 
   // Create a context into which we will load both the ember template compiler

--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -6,13 +6,19 @@
  * https://github.com/dgeb/grunt-ember-templates/blob/master/LICENSE
  */
 
-function manualCompile(handlebarsPath, templateCompilerPath, template){
+function manualCompile(handlebarsPath, templateCompilerPath, template, grunt){
   'use strict';
 
-  var fs                 = require('fs'),
-      vm                 = require('vm'),
-      handlebarsJs       = fs.readFileSync(handlebarsPath, 'utf8'),
-      templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
+  var fs = require('fs'),
+      vm = require('vm');
+
+  try {
+    var handlebarsJs       = fs.readFileSync(handlebarsPath, 'utf8'),
+        templateCompilerJs = fs.readFileSync(templateCompilerPath, 'utf8');
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+    grunt.fail.warn('Please setup handlebarsPath and templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
+  }
 
   // Create a context into which we will load both the ember template compiler
   // as well as the template to be compiled. The ember template compiler expects
@@ -35,12 +41,11 @@ function manualCompile(handlebarsPath, templateCompilerPath, template){
   vm.runInContext('compiledJS = (module.exports || exports).precompile(template);', context);
 
   return context.compiledJS;
-};
+}
 
 module.exports = function(grunt) {
   'use strict';
 
-  var compiler = require('ember-template-compiler');
   var path = require('path');
 
   var writeFile = function(contents, dest, options) {
@@ -78,10 +83,10 @@ module.exports = function(grunt) {
         return options.templateName(file);
       },
       templateRegistration: function(name, contents) {
-        return 'Ember.TEMPLATES[' + JSON.stringify(name) + '] = ' + contents + ';'
+        return 'Ember.TEMPLATES[' + JSON.stringify(name) + '] = ' + contents + ';';
       },
-      handlebarsPath: null,
-      templateCompilerPath: null,
+      handlebarsPath: 'bower_components/ember/ember-template-compiler.js',
+      templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
       templateNamespace: 'HTMLBars'
     });
 
@@ -117,9 +122,9 @@ module.exports = function(grunt) {
             }
 
             if (options.handlebarsPath && options.templateCompilerPath) {
-              compiledTemplate = manualCompile(options.handlebarsPath, options.templateCompilerPath, template);
+              compiledTemplate = manualCompile(options.handlebarsPath, options.templateCompilerPath, template, grunt);
             } else {
-              compiledTemplate = compiler.precompile(template, false).toString();
+              grunt.fail.warn('Please setup handlebarsPath and templateCompilerPath in options. It has to point to ember-template-compiler.js which bundled with Ember.js. The default path: bower_components/ember/ember-template-compiler.js');
             }
 
             // Wrap compiled template

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -141,34 +141,34 @@ exports.handlebars = {
   
     test.done();
   },
-  // custom_template_namespace: function(test){
-  //   'use strict';
-  //   test.expect(1);
-  //
-  //   var actual = grunt.file.read('tmp/custom_template_namespace.js');
-  //
-  //   test.ok(/Ember\.Handlebars\.template/.test(actual), 'should use the provided namespace');
-  //
-  //   test.done();
-  // },
-  // concatenate_disabled: function(test){
-  //   'use strict';
-  //   test.expect(3);
-  //
-  //   var desc = 'should write individual files if concatenation is disabled';
-  //
-  //   var actual = grunt.file.read('tmp/dest/test/fixtures/text.js');
-  //   var expected = grunt.file.read('test/expected/text.js');
-  //   test.equal(actual, expected, desc);
-  //
-  //   actual = grunt.file.read('tmp/dest/test/fixtures/simple.js');
-  //   expected = grunt.file.read('test/expected/simple.js');
-  //   test.equal(actual, expected, desc);
-  //
-  //   actual = grunt.file.read('tmp/dest/slash/test/fixtures/simple.js');
-  //   expected = grunt.file.read('test/expected/simple.js');
-  //   test.equal(actual, expected, desc);
-  //
-  //   test.done();
-  // }
+  custom_template_namespace: function(test){
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/custom_template_namespace.js');
+
+    test.ok(/Ember\.Handlebars\.template/.test(actual), 'should use the provided namespace');
+
+    test.done();
+  },
+  concatenate_disabled: function(test){
+    'use strict';
+    test.expect(3);
+
+    var desc = 'should write individual files if concatenation is disabled';
+
+    var actual = grunt.file.read('tmp/dest/test/fixtures/text.js');
+    var expected = grunt.file.read('test/expected/text.js');
+    test.equal(actual, expected, desc);
+
+    actual = grunt.file.read('tmp/dest/test/fixtures/simple.js');
+    expected = grunt.file.read('test/expected/simple.js');
+    test.equal(actual, expected, desc);
+
+    actual = grunt.file.read('tmp/dest/slash/test/fixtures/simple.js');
+    expected = grunt.file.read('test/expected/simple.js');
+    test.equal(actual, expected, desc);
+
+    test.done();
+  }
 };

--- a/test/ember_handlebars_test.js
+++ b/test/ember_handlebars_test.js
@@ -14,11 +14,11 @@ exports.handlebars = {
   amd: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/amd.js');
     var expected = grunt.file.read('test/expected/amd.js');
     test.equal(actual, expected, 'should compile handlebars templates with AMD wrappers');
-
+  
     test.done();
   },
   amd_string_true: function(test) {
@@ -44,11 +44,11 @@ exports.handlebars = {
   file_pattern_matching: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/file_pattern_matching.js');
     var expected = grunt.file.read('test/expected/file_pattern_matching.js');
     test.equal(actual, expected, 'should compile handlebars templates found by file pattern');
-
+  
     test.done();
   },
   custom_file_extensions: function(test) {
@@ -64,41 +64,41 @@ exports.handlebars = {
   truncate_base_path: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/truncate_base_path.js');
     var expected = grunt.file.read('test/expected/truncate_base_path.js');
     test.equal(actual, expected, 'should truncate base path from template names');
-
+  
     test.done();
   },
   remove_leading_slash: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/remove_leading_slash.js');
     var expected = grunt.file.read('test/expected/truncate_base_path.js');
     test.equal(actual, expected, 'should remove leading slash from template names');
-
+  
     test.done();
   },
   custom_template_name: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/custom_template_name.js');
     var expected = grunt.file.read('test/expected/custom_template_name.js');
     test.equal(actual, expected, 'should allow for custom processing of template names');
-
+  
     test.done();
   },
   custom_template_name_from_file: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/custom_template_name_from_file.js');
     var expected = grunt.file.read('test/expected/custom_template_name_from_file.js');
     test.equal(actual, expected, 'should allow for completely custom processing of template file names');
-
+  
     test.done();
   },
   minify: function(test) {
@@ -124,51 +124,51 @@ exports.handlebars = {
   custom_registration: function(test) {
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/custom_registration.js');
     var expected = grunt.file.read('test/expected/custom_registration.js');
     test.equal(actual, expected, 'should allow for custom generation of registration code');
-
+  
     test.done();
   },
   custom_template_compiler: function(test){
     'use strict';
     test.expect(1);
-
+  
     var actual = grunt.file.read('tmp/custom_handlebars_path.js');
-
-    test.ok(/WOOT/.test(actual), 'should use the provided handlebarsPath');
-
+  
+    test.ok(/WOOT/.test(actual), 'should use the provided templateCompilerPath');
+  
     test.done();
   },
-  custom_template_namespace: function(test){
-    'use strict';
-    test.expect(1);
-
-    var actual = grunt.file.read('tmp/custom_template_namespace.js');
-
-    test.ok(/Ember\.Handlebars\.template/.test(actual), 'should use the provided namespace');
-
-    test.done();
-  },
-  concatenate_disabled: function(test){
-    'use strict';
-    test.expect(3);
-
-    var desc = 'should write individual files if concatenation is disabled';
-
-    var actual = grunt.file.read('tmp/dest/test/fixtures/text.js');
-    var expected = grunt.file.read('test/expected/text.js');
-    test.equal(actual, expected, desc);
-
-    actual = grunt.file.read('tmp/dest/test/fixtures/simple.js');
-    expected = grunt.file.read('test/expected/simple.js');
-    test.equal(actual, expected, desc);
-
-    actual = grunt.file.read('tmp/dest/slash/test/fixtures/simple.js');
-    expected = grunt.file.read('test/expected/simple.js');
-    test.equal(actual, expected, desc);
-
-    test.done();
-  }
+  // custom_template_namespace: function(test){
+  //   'use strict';
+  //   test.expect(1);
+  //
+  //   var actual = grunt.file.read('tmp/custom_template_namespace.js');
+  //
+  //   test.ok(/Ember\.Handlebars\.template/.test(actual), 'should use the provided namespace');
+  //
+  //   test.done();
+  // },
+  // concatenate_disabled: function(test){
+  //   'use strict';
+  //   test.expect(3);
+  //
+  //   var desc = 'should write individual files if concatenation is disabled';
+  //
+  //   var actual = grunt.file.read('tmp/dest/test/fixtures/text.js');
+  //   var expected = grunt.file.read('test/expected/text.js');
+  //   test.equal(actual, expected, desc);
+  //
+  //   actual = grunt.file.read('tmp/dest/test/fixtures/simple.js');
+  //   expected = grunt.file.read('test/expected/simple.js');
+  //   test.equal(actual, expected, desc);
+  //
+  //   actual = grunt.file.read('tmp/dest/slash/test/fixtures/simple.js');
+  //   expected = grunt.file.read('test/expected/simple.js');
+  //   test.equal(actual, expected, desc);
+  //
+  //   test.done();
+  // }
 };

--- a/test/expected/amd.js
+++ b/test/expected/amd.js
@@ -1,20 +1,123 @@
 define(["ember"], function(Ember){
 
-Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
 });

--- a/test/expected/amd_custom.js
+++ b/test/expected/amd_custom.js
@@ -1,20 +1,123 @@
 define(["custom"], function(Ember){
 
-Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
 });

--- a/test/expected/custom_file_extensions.js
+++ b/test/expected/custom_file_extensions.js
@@ -1,12 +1,82 @@
-Ember.TEMPLATES["test/fixtures/custom_file_extensions/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/custom_file_extensions/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/custom_file_extensions/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/custom_file_extensions/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/custom_registration.js
+++ b/test/expected/custom_registration.js
@@ -1,12 +1,82 @@
-define('templates/test/fixtures/text', ['ember'], function(Ember) { return Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true}); });
+define('templates/test/fixtures/text', ['ember'], function(Ember) { return Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}())); });
 
-define('templates/test/fixtures/simple', ['ember'], function(Ember) { return Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true}); });
+define('templates/test/fixtures/simple', ['ember'], function(Ember) { return Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}())); });

--- a/test/expected/custom_template_name.js
+++ b/test/expected/custom_template_name.js
@@ -1,16 +1,119 @@
-Ember.TEMPLATES["text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/custom_template_name_from_file.js
+++ b/test/expected/custom_template_name_from_file.js
@@ -1,16 +1,119 @@
-Ember.TEMPLATES["text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/default.js
+++ b/test/expected/default.js
@@ -1,16 +1,119 @@
-Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/file_pattern_matching.js
+++ b/test/expected/file_pattern_matching.js
@@ -1,12 +1,82 @@
-Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/preprocess.js
+++ b/test/expected/preprocess.js
@@ -1,7 +1,62 @@
-Ember.TEMPLATES["test/fixtures/preprocess"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = '';
-  data.buffer.push("<div> <div>Spaces</div> <div>Tabs</div> <div class=\"spaces in attrs\"></div> ");
-  data.buffer.push(escapeExpression(((helpers.spaces || (depth0 && depth0.spaces) || helperMissing).call(depth0, "in", "handlebars", "tags", {"name":"spaces","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID","ID","ID"],"contexts":[depth0,depth0,depth0],"data":data}))));
-  data.buffer.push(" </div>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/preprocess"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("div");
+      var el2 = dom.createTextNode(" ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createElement("div");
+      var el3 = dom.createTextNode("Spaces");
+      dom.appendChild(el2, el3);
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(" ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createElement("div");
+      var el3 = dom.createTextNode("Tabs");
+      dom.appendChild(el2, el3);
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(" ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createElement("div");
+      dom.setAttribute(el2,"class","spaces in attrs");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(" ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(" ");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, get = hooks.get, inline = hooks.inline;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),7,7);
+      inline(env, morph0, context, "spaces", [get(env, context, "in"), get(env, context, "handlebars"), get(env, context, "tags")], {});
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/simple.js
+++ b/test/expected/simple.js
@@ -1,8 +1,45 @@
-Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["test/fixtures/simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/text.js
+++ b/test/expected/text.js
@@ -1,3 +1,36 @@
-Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["test/fixtures/text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/expected/truncate_base_path.js
+++ b/test/expected/truncate_base_path.js
@@ -1,16 +1,119 @@
-Ember.TEMPLATES["text"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Basic template that does nothing.");
-  },"useData":true});
+Ember.TEMPLATES["text"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Basic template that does nothing.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["simple"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, buffer = '';
-  data.buffer.push("<p>Hello, my name is ");
-  stack1 = helpers._triageMustache.call(depth0, "name", {"name":"_triageMustache","hash":{},"hashTypes":{},"hashContexts":{},"types":["ID"],"contexts":[depth0],"data":data});
-  if (stack1 != null) { data.buffer.push(stack1); }
-  data.buffer.push(".</p>");
-  return buffer;
-},"useData":true});
+Ember.TEMPLATES["simple"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createElement("p");
+      var el2 = dom.createTextNode("Hello, my name is ");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createComment("");
+      dom.appendChild(el1, el2);
+      var el2 = dom.createTextNode(".");
+      dom.appendChild(el1, el2);
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      var hooks = env.hooks, content = hooks.content;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      var morph0 = dom.createMorphAt(dom.childAt(fragment, [0]),1,1);
+      content(env, morph0, context, "name");
+      return fragment;
+    }
+  };
+}()));
 
-Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  data.buffer.push("Should be nested.");
-  },"useData":true});
+Ember.TEMPLATES["grandparent/parent/child"] = Ember.HTMLBars.template((function() {
+  return {
+    isHTMLBars: true,
+    revision: "Ember@1.12.2",
+    blockParams: 0,
+    cachedFragment: null,
+    hasRendered: false,
+    build: function build(dom) {
+      var el0 = dom.createDocumentFragment();
+      var el1 = dom.createTextNode("Should be nested.");
+      dom.appendChild(el0, el1);
+      return el0;
+    },
+    render: function render(context, env, contextualElement) {
+      var dom = env.dom;
+      dom.detectNamespace(contextualElement);
+      var fragment;
+      if (env.useFragmentCache && dom.canClone) {
+        if (this.cachedFragment === null) {
+          fragment = this.build(dom);
+          if (this.hasRendered) {
+            this.cachedFragment = fragment;
+          } else {
+            this.hasRendered = true;
+          }
+        }
+        if (this.cachedFragment) {
+          fragment = dom.cloneNode(this.cachedFragment, true);
+        }
+      } else {
+        fragment = this.build(dom);
+      }
+      return fragment;
+    }
+  };
+}()));

--- a/test/fixtures/dummy-handlebars.js
+++ b/test/fixtures/dummy-handlebars.js
@@ -1,2 +1,0 @@
-var Handlebars = {}
-Handlebars.VERSION = 'WOOT CUSTOM HANDLEBARS'

--- a/test/fixtures/dummy-template-compiler.js
+++ b/test/fixtures/dummy-template-compiler.js
@@ -1,3 +1,3 @@
 exports.precompile = function(){
-  return "Version: " + Handlebars.VERSION + " - 'Some random text here'";
-}
+  return "Version: WOOT CUSTOM HANDLEBARS - 'Some random text here'";
+};


### PR DESCRIPTION
* Removed `ember-template-compiler` npm dependency.
* Removed `handlebar` npm dependency.
* Removed `handlebarsPath` option.
* Require Ember's bundled `ember-template-compiler.js`, default location: `bower_components/ember/ember-template-compiler.js`.
* Update all tests.
* Update `grunt` peerDependencies to support grunt v1.0.
* Update Readme.md with the new defaults.