### PR TITLE
Pass the file path to `preprocess` function

### DIFF
--- a/tasks/ember_templates.js
+++ b/tasks/ember_templates.js
@@ -117,7 +117,7 @@ module.exports = function(grunt) {
 
             // Run the `preprocess` function if specified in the options.
             if (typeof options.preprocess === 'function') {
-              template = options.preprocess(template);
+              template = options.preprocess(template, file);
             }
 
             compiledTemplate = manualCompile(options.templateCompilerPath, template, grunt);


### PR DESCRIPTION
I need to do some manipulations with images paths inside a template, and I need to know the template's path in order to find an image by it's relative path. So I think it's worth it to pass `file` to the `preprocess` function.