### PR TITLE
Allow specifying a concatenate function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
     emberTemplates: {
       'default': {
         files: {
-          'tmp/default.js': ['test/fixtures/text.hbs',
+          'tmp/default.js': [
+            'test/fixtures/text.hbs',
             'test/fixtures/simple.hbs',
             'test/fixtures/grandparent/parent/child.hbs'
           ]
@@ -207,6 +208,24 @@ module.exports = function(grunt) {
             'test/fixtures/simple.hbs'
           ],
           'tmp/dest/slash/': ['test/fixtures/simple.hbs']
+        }
+      },
+      concatenateFunction: {
+        options: {
+          concatenate: function(output, processedTemplates) {
+            output = output.concat('(function(){');
+            return output.concat(
+              processedTemplates.map(function (template) {
+                return template.contents;
+              })).concat('})();');
+          }
+        },
+        files: {
+          'tmp/concatenate_function.js': [
+            'test/fixtures/text.hbs',
+            'test/fixtures/simple.hbs',
+            'test/fixtures/grandparent/parent/child.hbs'
+          ]
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ options: {
 
 ##### concatenate
 
-Type: `boolean`
+Type: `boolean` or `function`
 Default: `true`
 
 Disable this option to compile the templates to multiple individual files,
@@ -116,6 +116,21 @@ options: {
 },
 files: {
   "path/to/destination/folder": ["path/to/sources/*.handlebars", "path/to/more/*.handlebars"]
+}
+```
+
+Alternatively, you can specify your own function to do the concatenation. Here's
+an example that wraps the output in an IIFE:
+
+``` javascript
+options: {
+  concatenate: function(output, processedTemplates) {
+    output = output.concat('(function(){');
+    return output.concat(
+      processedTemplates.map(function (template) {
+        return template.contents;
+      })).concat('})();');
+  }
 }
 ```
 

--- a/tasks/ember-templates.js
+++ b/tasks/ember-templates.js
@@ -144,11 +144,15 @@ module.exports = function(grunt) {
       });
 
       if (options.concatenate) {
-        // Map over the 'contents' property and concatenate
-        output = output.concat(
-          processedTemplates.map(function(template) {
-            return template.contents;
-          }));
+        if (typeof options.concatenate === 'function') {
+          output = options.concatenate(output, processedTemplates);
+        } else {
+          // Map over the 'contents' property and concatenate
+          output = output.concat(
+            processedTemplates.map(function(template) {
+              return template.contents;
+            }));
+        }
 
         writeFile(output, f.dest, options);
 

--- a/test/grunt-ember-templates-test.js
+++ b/test/grunt-ember-templates-test.js
@@ -177,5 +177,16 @@ exports.default = {
     test.equal(actual, expected, desc);
 
     test.done();
+  },
+  concatenate_function: function (test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/concatenate_function.js');
+    var expected = grunt.file.read('test/expected/' + this.version + '/default.js');
+    expected = '(function(){\n\n' + expected + '\n\n})();';
+    test.equal(actual, expected, 'should compile handlebars templates using default settings');
+
+    test.done();
   }
 };


### PR DESCRIPTION
This is a backward compatible change that allows specifying a function for the concatenate option. Its main use case is to allow post-processing the output